### PR TITLE
Add cmd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 # Installation
 
+On a POSIXish system:
+
 ```
-curl https://raw.githubusercontent.com/ben-biddington/xp-mode/master/install.sh | bash && source xp-mode.sh 
+curl https://raw.githubusercontent.com/ben-biddington/xp-mode/master/install.sh | bash && source xp-mode.sh
 ```
 
 [Read what installer does](/install.sh)
+
+For a windows cmd prompt:
+
+```
+curl https://raw.githubusercontent.com/ben-biddington/xp-mode/master/install.bat
+curl https://raw.githubusercontent.com/ben-biddington/xp-mode/master/xp-mode.bat
+.\install.bat
+```
 
 # Configuration
 
@@ -30,7 +40,7 @@ Ben, Danny and Gareth ; gareth.keenan@aol.com
 Show your pairs by calling `pair` with no arguments:
 
 ```
-$ pair 
+$ pair
 You have the following <5> pairs in file </home/ben/.pairs>:
 
 [1] Ben Biddington; ben.biddington@gmail.com

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,8 @@
+@echo off
+
+setlocal
+
+set filename=C:\Windows\pair.bat
+
+echo @echo off > %filename%
+echo %cd%\xp-mode.bat %%* >> %filename%

--- a/xp-mode.bat
+++ b/xp-mode.bat
@@ -1,0 +1,72 @@
+@echo off
+
+if not exist %HOME%\.pairs (
+  echo Config file %HOME%\.pairs is missing
+  exit /b
+)
+
+set lines=1
+
+if [%1] == [] (
+   call :count-lines
+   exit /b
+) else (
+   call :set-author %1
+   exit /b
+)
+
+:count-lines (
+  setlocal
+  set lines=0
+  for /f %%i in ('type %HOME%\.pairs^|find "" /v /c') do set lines=%%i
+  echo You have the following %lines% pairs in file %HOME%\.pairs
+
+  for /f "tokens=* delims=" %%i in (%HOME%\.pairs) do echo %%i
+  endlocal
+  exit /b
+)
+
+:trim (
+  setlocal enabledelayedexpansion
+  set args=%*
+  for /f "tokens=1*" %%a in ("!args!") do endlocal & set %1=%%b
+  exit /b
+)
+
+:set-author (
+  setlocal enabledelayedexpansion
+  set line=%1
+  set /a line-=1
+
+  for /f "usebackq delims=" %%l in (`more +%line% %HOME%\.pairs`) do (
+    set pair=%%l
+    goto :jump
+  )
+  :jump
+
+  for /f "tokens=1 delims=;" %%p in ("%pair%") do (
+    set value=%%p
+    call :trim result !value!
+    set author_name=!result!
+  )
+
+  for /f "tokens=2 delims=;" %%p in ("%pair%") do (
+    set value=%%p
+    call :trim result !value!
+    set author_email=!result!
+  )
+
+  echo setting GIT_AUTHOR_NAME=%author_name%
+  echo setting GIT_AUTHOR_EMAIL=%author_email%
+
+  endlocal & set author_name=%author_name% & set author_email=%author_email%
+)
+
+set GIT_AUTHOR_NAME=%author_name%
+set GIT_AUTHOR_EMAIL=%author_email%
+
+echo Author is now %GIT_AUTHOR_NAME%;%GIT_AUTHOR_EMAIL%
+setlocal
+for /f "usebackq tokens=*" %%a in (`git config user.name`) do echo Committer name is %%a
+for /f "usebackq tokens=*" %%a in (`git config user.email`) do echo Committer email is %%a
+endlocal


### PR DESCRIPTION
Haven't had enough `GOTO`s in my life recently.

Is it possible for a bash prompt to set an environment variable in its parent shell? I couldn't find a way, but a simpler approach than duplicating the sh into bat would be to just introduce a bat on PATH that proxies onto the bash version with `bash --login -i -c` -- but I don't think the child process can set the variables needed.

@ben-biddington 
